### PR TITLE
turn off backlight of char display when stopped.

### DIFF
--- a/srv/http/bash/lcdchar.py
+++ b/srv/http/bash/lcdchar.py
@@ -28,7 +28,7 @@ rows = cols == 16 and 2 or 4
 if address: # i2c
     from RPLCD.i2c import CharLCD
     lcd = CharLCD( chip, address )
-    lcd = CharLCD( cols=cols, rows=rows, charmap=charmap, address=address, i2c_expander=chip, auto_linebreaks=False )
+    lcd = CharLCD( cols=cols, rows=rows, charmap=charmap, address=address, i2c_expander=chip, auto_linebreaks=False, backlight_enabled=True )
 else:
     from RPLCD.gpio import CharLCD
     from RPi import GPIO
@@ -191,10 +191,15 @@ if charmap == 'A00':
     lines = ''.join( c for c in unicodedata.normalize( 'NFD', lines ) if unicodedata.category( c ) != 'Mn' )
 
 lcd.write_string( lines + rn + progress[ :cols ] )
+
+if state == 'stop':
+    lcd.backlight_enabled = False
     
 if state == 'stop' or state == 'pause':
     lcd.close()
     quit()
+
+lcd.backlight_enabled = False
 
 # play
 if elapsed == 'false': quit()


### PR DESCRIPTION
I'm not a Pythoneer, but this seems to work with my 1602A LCD with I2C backpack. Just turn of backlight when stopped, turn on otherwise.